### PR TITLE
Fix Voiding Input Resources Bug & fix some Repeating Code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.mooy1</groupId>
     <artifactId>InfinityLib</artifactId>
-    <version>1.3.9</version>
+    <version>1.4.0</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/io/github/mooy1/infinitylib/machines/MachineBlock.java
+++ b/src/main/java/io/github/mooy1/infinitylib/machines/MachineBlock.java
@@ -161,7 +161,7 @@ public final class MachineBlock extends AbstractMachineBlock {
             }
 
             //Add the Amount of FreeSpace that is Left in the Stack
-            freeSpace += 64 - itemStack.getAmount();
+            freeSpace += itemStack.getMaxStackSize() - itemStack.getAmount();
         }
 
         return freeSpace;

--- a/src/main/java/io/github/mooy1/infinitylib/machines/MachineBlock.java
+++ b/src/main/java/io/github/mooy1/infinitylib/machines/MachineBlock.java
@@ -151,7 +151,7 @@ public final class MachineBlock extends AbstractMachineBlock {
             //Get the Item in the Slot and Check if it's an Actual Item
             ItemStack itemStack = menu.getItemInSlot(slotNumber);
             if (itemStack == null || itemStack.getType() == Material.AIR) {
-                freeSpace += 64;
+                freeSpace += toWrap.getMaxStackSize();
                 continue;
             }
 

--- a/src/main/java/io/github/mooy1/infinitylib/machines/MachineBlock.java
+++ b/src/main/java/io/github/mooy1/infinitylib/machines/MachineBlock.java
@@ -11,6 +11,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 import lombok.Setter;
 
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
 
@@ -19,6 +20,7 @@ import io.github.mooy1.infinitylib.core.AbstractAddon;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.ItemUtils;
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
@@ -99,26 +101,26 @@ public final class MachineBlock extends AbstractMachineBlock {
         }
 
         MachineBlockRecipe recipe = getOutput(input);
+
         if (recipe != null) {
+            if (!(getFreeSpace(layout.outputSlots(), recipe.output.clone(), menu) >= recipe.output.getAmount())) {
+                displayIfViewer(menu, NO_ROOM_ITEM);
+                return false;
+            }
+
             ItemStack rem = menu.pushItem(recipe.output.clone(), layout.outputSlots());
-            if (rem == null || rem.getAmount() < recipe.output.getAmount()) {
+            if (rem == null) {
                 recipe.consume();
-                if (menu.hasViewer()) {
-                    menu.replaceExistingItem(getStatusSlot(), PROCESSING_ITEM);
-                }
+                displayIfViewer(menu, PROCESSING_ITEM);
                 return true;
             }
             else {
-                if (menu.hasViewer()) {
-                    menu.replaceExistingItem(getStatusSlot(), NO_ROOM_ITEM);
-                }
+                displayIfViewer(menu, NO_ROOM_ITEM);
                 return false;
             }
         }
 
-        if (menu.hasViewer()) {
-            menu.replaceExistingItem(getStatusSlot(), IDLE_ITEM);
-        }
+        displayIfViewer(menu, IDLE_ITEM);
         return false;
     }
 
@@ -141,6 +143,34 @@ public final class MachineBlock extends AbstractMachineBlock {
             }
         }
         return null;
+    }
+
+    int getFreeSpace(int[] slots, ItemStack toWrap, BlockMenu menu) {
+        int freeSpace = 0;
+        for (int slotNumber : slots) {
+            //Get the Item in the Slot and Check if it's an Actual Item
+            ItemStack itemStack = menu.getItemInSlot(slotNumber);
+            if (itemStack == null || itemStack.getType() == Material.AIR) {
+                freeSpace += 64;
+                continue;
+            }
+
+            //If the Items can't stack then continue to the next Slot
+            if (!ItemUtils.canStack(toWrap, itemStack)) {
+                continue;
+            }
+
+            //Add the Amount of FreeSpace that is Left in the Stack
+            freeSpace += 64 - itemStack.getAmount();
+        }
+
+        return freeSpace;
+    }
+
+    void displayIfViewer(@Nonnull BlockMenu menu, @Nonnull ItemStack toDisplay) {
+        if (menu.hasViewer()) {
+            menu.replaceExistingItem(getStatusSlot(), toDisplay);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Making this Pull Request to Fix a Very annoying Bug.
The bug in question is when a Machine Block, for Example the Cobble Press,
Gets Enough input items for a Recipe But does not have enough room in the Output slots to hold all of those Items
It will consume all of the Input items and put as many as it can into the Output Slots, Effectively voiding the input items that are used on the Outputted items that weren't able to be Fit.

As a Summary:
Cobble Press has 1 Stack and 63 Double Compressed Cobblestone in It's Output Slots
You input 1 Stack of Single Compressed Cobble
It Gets used and the Output now is 2 Stacks of Double Compressed Cobblestone

## Code Changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
I made 2 new methods
1 will calculate the free space in Slots provided
the Other just Reduces Repeated Code

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
- [x] I have also tested the proposed changes with an addon.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I have added `Nullable` or `Nonnull` annotations to my methods
- [x] I have added sufficient Unit Tests to cover my code.
- [x] I updated the version in pom.xml according to semantic versioning.
