### PR TITLE
permission node

### DIFF
--- a/src/main/java/io/github/mooy1/infinitylib/machines/MenuBlockPreset.java
+++ b/src/main/java/io/github/mooy1/infinitylib/machines/MenuBlockPreset.java
@@ -41,7 +41,7 @@ final class MenuBlockPreset extends BlockMenuPreset {
 
     @Override
     public boolean canOpen(Block b, Player p) {
-        return Slimefun.getProtectionManager().hasPermission(p, b.getLocation(), Interaction.INTERACT_BLOCK)
+        return Slimefun.getProtectionManager().hasPermission(p, b.getLocation(), Interaction.INTERACT_BLOCK || p.hasPermission("slimefun.inventory.bypass"))
                 && menuBlock.canUse(p, false);
     }
 


### PR DESCRIPTION
adds the missing option for a permission node which is found in default slimefun machines for protection managers

## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
im making this pull requests as almost all slimefun machines have this option in them and this adds that option which will allow   anyone who uses infinitylib to get more of their options 
## Code Changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
added permisisonnode option for machinemenu protection manager
## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
- [ ] I have also tested the proposed changes with an addon.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I have added `Nullable` or `Nonnull` annotations to my methods
- [ ] I have added sufficient Unit Tests to cover my code.
- [ ] I updated the version in pom.xml according to semantic versioning.
