### PR TITLE
Add AbstractMachineBlock#getEnergyPerTick

### DIFF
--- a/src/main/java/io/github/mooy1/infinitylib/machines/AbstractMachineBlock.java
+++ b/src/main/java/io/github/mooy1/infinitylib/machines/AbstractMachineBlock.java
@@ -43,6 +43,10 @@ public abstract class AbstractMachineBlock extends TickingMenuBlock implements E
 
     protected abstract int getStatusSlot();
 
+    public final int getEnergyPerTick() {
+        return energyPerTick;
+    }
+
     @Override
     public final int getCapacity() {
         return energyCapacity;


### PR DESCRIPTION
## Description
To allow for other addons to get more info about InfinityLib based machines

## Code Changes
- added AbstractMachineBlock#getEnergyPerTick

## Related Issues
No related issues

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
- [x] I have also tested the proposed changes with an addon.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I have added `Nullable` or `Nonnull` annotations to my methods
- [x] I have added sufficient Unit Tests to cover my code.
- [ ] I updated the version in pom.xml according to semantic versioning.
