### PR TITLE
Add getRecipes Methods to CraftingBlock and MachineBlock

### DIFF
--- a/src/main/java/io/github/mooy1/infinitylib/machines/CraftingBlock.java
+++ b/src/main/java/io/github/mooy1/infinitylib/machines/CraftingBlock.java
@@ -132,6 +132,7 @@ public class CraftingBlock extends MenuBlock {
      * Returns an unmodifiable version of {@link CraftingBlock#recipes}
      * @return {@link List}
      */
+    @Nonnull
     public List<CraftingBlockRecipe> getRecipes() {
         return Collections.unmodifiableList(this.recipes);
     }

--- a/src/main/java/io/github/mooy1/infinitylib/machines/CraftingBlock.java
+++ b/src/main/java/io/github/mooy1/infinitylib/machines/CraftingBlock.java
@@ -1,6 +1,7 @@
 package io.github.mooy1.infinitylib.machines;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.Nonnull;
@@ -127,4 +128,11 @@ public class CraftingBlock extends MenuBlock {
         return layout.outputSlots();
     }
 
+    /**
+     * Returns an unmodifiable version of {@link CraftingBlock#recipes}
+     * @return {@link List}
+     */
+    public List<CraftingBlockRecipe> getRecipes() {
+        return Collections.unmodifiableList(this.recipes);
+    }
 }

--- a/src/main/java/io/github/mooy1/infinitylib/machines/MachineBlock.java
+++ b/src/main/java/io/github/mooy1/infinitylib/machines/MachineBlock.java
@@ -153,6 +153,7 @@ public final class MachineBlock extends AbstractMachineBlock {
      * Returns an unmodifiable version of {@link MachineBlock#recipes}
      * @return {@link List}
      */
+    @Nonnull
     public List<MachineBlockRecipe> getRecipes() {
         return Collections.unmodifiableList(this.recipes);
     }

--- a/src/main/java/io/github/mooy1/infinitylib/machines/MachineBlock.java
+++ b/src/main/java/io/github/mooy1/infinitylib/machines/MachineBlock.java
@@ -1,6 +1,7 @@
 package io.github.mooy1.infinitylib.machines;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -148,4 +149,11 @@ public final class MachineBlock extends AbstractMachineBlock {
         return layout.statusSlot();
     }
 
+    /**
+     * Returns an unmodifiable version of {@link MachineBlock#recipes}
+     * @return {@link List}
+     */
+    public List<MachineBlockRecipe> getRecipes() {
+        return Collections.unmodifiableList(this.recipes);
+    }
 }


### PR DESCRIPTION
## Description
This adds 2 new api methods to allow developers more leniency when working with InfinityLib

## Code Changes
- Added CraftingBlock#getRecipes()
- Added MachineBlock#getRecipes()

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
- [x] I have also tested the proposed changes with an addon.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I have added `Nullable` or `Nonnull` annotations to my methods
- [x] I have added sufficient Unit Tests to cover my code.
- [ ] I updated the version in pom.xml according to semantic versioning.
